### PR TITLE
PMM-3353 postgres_exporter does not work with PG11

### DIFF
--- a/cmd/postgres_exporter/pg_setting.go
+++ b/cmd/postgres_exporter/pg_setting.go
@@ -96,7 +96,7 @@ func (s *pgSetting) normaliseUnit() (val float64, unit string, err error) {
 		return
 	case "ms", "s", "min", "h", "d":
 		unit = "seconds"
-	case "kB", "MB", "GB", "TB", "8kB", "16kB", "32kB", "16MB", "32MB", "64MB":
+	case "B","kB", "MB", "GB", "TB", "8kB", "16kB", "32kB", "16MB", "32MB", "64MB":
 		unit = "bytes"
 	default:
 		err = fmt.Errorf("Unknown unit for runtime variable: %q", s.unit)


### PR DESCRIPTION
applying changes from https://github.com/wrouesnel/postgres_exporter/pull/222 