### PR TITLE
PMM-9541 Fix database discover when using socket

### DIFF
--- a/cmd/postgres_exporter/datasource.go
+++ b/cmd/postgres_exporter/datasource.go
@@ -75,7 +75,11 @@ func (e *Exporter) discoverDatabaseDSNs() []string {
 			}
 
 			if dsnURI != nil {
-				dsnURI.Path = databaseName
+				if dsnURI.Host == "" && strings.HasPrefix(dsnURI.Path, "/") {
+					dsnURI.Path = "/" + databaseName
+				} else {
+					dsnURI.Path = databaseName
+				}
 				dsn = dsnURI.String()
 			} else {
 				// replacing one dbname with another is complicated.


### PR DESCRIPTION
When discovering databases and using local socket connection add trailing "/" to the database name to omit using it as a host for the connection.

Feature build:

 - https://github.com/Percona-Lab/pmm-submodules/pull/3240