### PR TITLE
PMM-13970 Adding where clause to exclude autovacuum from long transaction monitoring

### DIFF
--- a/cmd/postgres_exporter/queries.go
+++ b/cmd/postgres_exporter/queries.go
@@ -152,7 +152,7 @@ var queryOverrides = map[string][]OverrideQuery{
 					count(*) AS count,
 					MAX(EXTRACT(EPOCH FROM now() - xact_start))::float AS max_tx_duration,
 					MAX(EXTRACT(EPOCH FROM now() - state_change))::float AS max_state_duration
-				FROM pg_stat_activity GROUP BY datname,state,usename,application_name) AS tmp2
+				FROM pg_stat_activity WHERE query not like 'autovacuum:%' GROUP BY datname,state,usename,application_name) AS tmp2
 				ON tmp.state = tmp2.state AND pg_database.datname = tmp2.datname
 			`,
 		},


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PMM-13970

FB: https://github.com/Percona-Lab/pmm-submodules/pull/3928

Adding `WHERE query not like 'autovacuum:%'` to pg_stat_activity query to exclude autovacuum process from transaction age monitoring.